### PR TITLE
Fix issue where generated "matches" for a char regex didn't always ma…

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,16 +125,38 @@ val randomRegex1: Regex[Char] = regexGen.apply(Gen.Parameters.default, Seed(1057
 
 ```scala
 randomRegex1.pprint
-// res12: String = "(\u245b|\u6f40)*[\u637a-\ue1f7]\u87a6*\u8b69"
+// res12: String = "(\u245b|[\ua615-\uc4eb]\u64db)*.*([\uce76-\ud24f]\uaefa\u1363\u881f*|([\ud4b2-\ud618]|\u6ba1)\u7009)([\u8086-\ud694]\ube8e|.)"
 ```
 
-You can now generate random data to match this regular expression as described [here](#generating-data-that-matches-a-regular-expression).
+You can now generate random data to match this regular expression as described [here](#generating-data-that-matches-a-regular-expression). Alternatively, you can generate a regular expression and a match for it in one step:
 
-Sometimes you may want to generate both matches and non-matches for your random regular expression to make sure that both cases are handled. The `Arbitrary` instance for `RegexAndCandidate` will generate random regular expressions along with data that matches the regular expresssion roughly half of the time.
+```scala
+val regexAndMatchGen: Gen[RegexAndCandidate[Char]] =
+  CharRegexGen.genAlphaNumCharRegexAndMatch
+
+val regexesAndMatchesGen: Gen[List[RegexAndCandidate[Char]]] =
+  Gen.listOfN(4, regexAndMatchGen)
+
+val regexesAndMatches: List[RegexAndCandidate[Char]] = regexesAndMatchesGen.apply(Gen.Parameters.default.withSize(30), Seed(105773L)).get
+```
+
+```scala
+regexesAndMatches.map(x =>
+  (x.r.pprint, x.candidate.mkString)
+)
+// res13: List[(String, String)] = List(
+//   (".S[o-x]", "pSx"),
+//   ("7(Y|[e-k])u", "7iu"),
+//   ("sbb0(s|[7-n]*|[l-t]s).B.", "sbb0rszBG"),
+//   ("[a-j]", "i")
+// )
+```
+
+Sometimes you may want to generate both matches and non-matches for your random regular expression to make sure that both cases are handled. There are various `Gen` instances for `RegexAndCandidate` that will generate random regular expressions along with data that matches the regular expresssion roughly half of the time.
 
 ```scala
 val regexAndCandidateGen: Gen[RegexAndCandidate[Char]] =
-  RegexAndCandidate.genRegexAndCandidate(Gen.alphaNumChar, includeZero = false, includeOne = false)
+  CharRegexGen.genAlphaNumCharRegexAndCandidate
 
 val regexesAndCandidatesGen: Gen[List[RegexAndCandidate[Char]]] =
   Gen.listOfN(4, regexAndCandidateGen)
@@ -146,7 +168,7 @@ val regexesAndCandidates: List[RegexAndCandidate[Char]] = regexesAndCandidatesGe
 regexesAndCandidates.map(x =>
   (x.r.pprint, x.candidate.mkString, x.r.matcher[Stream].apply(x.candidate))
 )
-// res13: List[(String, String, Boolean)] = List(
+// res14: List[(String, String, Boolean)] = List(
 //   ("i*[e-r].[L-m][7-c]rqzakh[q-x][C-p][8-w]", "riK8acx3d", false),
 //   ("zhh(9z|z)[i-l].*", "zhhzklpawcbbw", true),
 //   ("m*.*.[7-d]", "mmmmmmmmmmmmmmmmmmmmmmmmm5thgxjucrTaA", true),
@@ -165,7 +187,7 @@ val inefficientRegex: Regex[Char] = lit('a').star.star.star
 
 ```scala
 inefficientRegex.pprint
-// res14: String = "((a*)*)*"
+// res15: String = "((a*)*)*"
 ```
 
 ```scala
@@ -174,7 +196,7 @@ val moreEfficientRegex: Regex[Char] = inefficientRegex.optimize
 
 ```scala
 moreEfficientRegex.pprint
-// res15: String = "a*"
+// res16: String = "a*"
 ```
 
 ## performance

--- a/docs/README.md
+++ b/docs/README.md
@@ -113,13 +113,29 @@ val randomRegex1: Regex[Char] = regexGen.apply(Gen.Parameters.default, Seed(1057
 randomRegex1.pprint
 ```
 
-You can now generate random data to match this regular expression as described [here](#generating-data-that-matches-a-regular-expression).
+You can now generate random data to match this regular expression as described [here](#generating-data-that-matches-a-regular-expression). Alternatively, you can generate a regular expression and a match for it in one step:
 
-Sometimes you may want to generate both matches and non-matches for your random regular expression to make sure that both cases are handled. The `Arbitrary` instance for `RegexAndCandidate` will generate random regular expressions along with data that matches the regular expresssion roughly half of the time.
+```scala mdoc:silent
+val regexAndMatchGen: Gen[RegexAndCandidate[Char]] =
+  CharRegexGen.genAlphaNumCharRegexAndMatch
+
+val regexesAndMatchesGen: Gen[List[RegexAndCandidate[Char]]] =
+  Gen.listOfN(4, regexAndMatchGen)
+
+val regexesAndMatches: List[RegexAndCandidate[Char]] = regexesAndMatchesGen.apply(Gen.Parameters.default.withSize(30), Seed(105773L)).get
+```
+
+```scala mdoc
+regexesAndMatches.map(x =>
+  (x.r.pprint, x.candidate.mkString)
+)
+```
+
+Sometimes you may want to generate both matches and non-matches for your random regular expression to make sure that both cases are handled. There are various `Gen` instances for `RegexAndCandidate` that will generate random regular expressions along with data that matches the regular expresssion roughly half of the time.
 
 ```scala mdoc:silent
 val regexAndCandidateGen: Gen[RegexAndCandidate[Char]] =
-  RegexAndCandidate.genRegexAndCandidate(Gen.alphaNumChar, includeZero = false, includeOne = false)
+  CharRegexGen.genAlphaNumCharRegexAndCandidate
 
 val regexesAndCandidatesGen: Gen[List[RegexAndCandidate[Char]]] =
   Gen.listOfN(4, regexAndCandidateGen)

--- a/regex-gen/src/main/scala/CharRegexGen.scala
+++ b/regex-gen/src/main/scala/CharRegexGen.scala
@@ -1,0 +1,56 @@
+package ceedubs.irrec
+package regex
+
+import RegexGen.{genRegex, genRangeMatch}
+import RegexAndCandidate.{genRegexAndCandidate, genRegexAndMatch}
+
+import org.scalacheck.Gen
+
+
+/**
+ * This providex support for generation of `Char` regular expressions.
+ *
+ * Parts of Unicode are a bit weird and probably don't make much sense inside of regular
+ * expressions. So for now at least we avoid the most fiddly of bits.
+ */
+object CharRegexGen {
+
+  val supportedCharRangesInclusive: List[(Char, Char)] = List(
+    (0x0000, 0xD7FF),
+    (0xF900, 0xFFFD))
+
+  /**
+   * Adapted from code in Scalacheck.
+   */
+  private val genSupportedCharRangeBounds: Gen[(Char, Char)] =
+    Gen.frequency((supportedCharRangesInclusive.map {
+      case (first, last) => (last + 1 - first, Gen.const((first, last)))
+    }: List[(Int, Gen[(Char, Char)])]): _*)
+
+  val genSupportedChar: Gen[Char] =
+    for {
+      bounds <- genSupportedCharRangeBounds
+      (min, max) = bounds
+      c <- Gen.choose(min, max)
+    } yield c
+
+  val genSupportedCharMatchRange: Gen[Match.Range[Char]] =
+    for {
+      bounds <- genSupportedCharRangeBounds
+      (min, max) = bounds
+      lower <- Gen.choose(min, max)
+      upper <- Gen.choose(lower, max)
+    } yield Match.Range(lower, upper)
+
+  def genRegexChar(includeZero: Boolean, includeOne: Boolean): Gen[Regex[Char]] = genRegex(genSupportedChar, genSupportedCharMatchRange, includeZero = includeZero, includeOne = includeOne)
+
+  val genStandardRegexChar: Gen[Regex[Char]] = genRegexChar(includeZero = false, includeOne = false)
+
+  val genCharRegexAndMatch: Gen[RegexAndCandidate[Char]] = genRegexAndMatch(includeOne = false, genSupportedChar, genSupportedCharMatchRange)
+
+  val genAlphaNumCharRegexAndMatch: Gen[RegexAndCandidate[Char]] = genRegexAndMatch(includeOne = false, Gen.alphaNumChar, genRangeMatch(Gen.alphaNumChar))
+
+  val genCharRegexAndCandidate: Gen[RegexAndCandidate[Char]] = genRegexAndCandidate(genSupportedChar, genSupportedCharMatchRange, includeZero = false, includeOne = false)
+
+  val genAlphaNumCharRegexAndCandidate: Gen[RegexAndCandidate[Char]] = genRegexAndCandidate(Gen.alphaNumChar, genRangeMatch(Gen.alphaNumChar), includeZero = false, includeOne = false)
+}

--- a/regex-gen/src/main/scala/RegexShrink.scala
+++ b/regex-gen/src/main/scala/RegexShrink.scala
@@ -1,0 +1,51 @@
+package ceedubs.irrec
+package regex
+
+import qq.droste.{AlgebraM, scheme}
+import qq.droste.data.{Coattr, CoattrF}
+import qq.droste.data.prelude._
+import org.scalacheck.Shrink
+import cats.implicits._
+
+object RegexShrink {
+
+  def shrinkKleeneF[A]: KleeneF[Regex[A]] => Stream[Regex[A]] = {
+    case KleeneF.Plus(l, r) => l #:: r #:: (l | r) #:: Stream.empty
+    case KleeneF.Times(l, r) => l #:: r #:: (l * r) #:: Stream.empty
+    case KleeneF.Star(g) => Stream(g)
+    case KleeneF.Zero => Stream.empty
+    case KleeneF.One => Stream.empty
+  }
+
+  def shrinkMatch[A](implicit shrinkA: Shrink[A]): Match[A] => Stream[Match[A]] = {
+    case Match.Literal(expected) => shrinkA.shrink(expected).map(Match.Literal(_))
+    case Match.Wildcard => Stream.empty
+    case Match.Range(l, r) =>
+      val shrunkLeft = shrinkA.shrink(l).map(l2 => Match.Range(l2, r))
+      val shrunkRight = shrinkA.shrink(r).map(r2 => Match.Range(l, r2))
+      shrunkLeft append shrunkRight
+  }
+
+  def shrinkRegexCoattrF[A:Shrink]: CoattrF[KleeneF, Match[A], Regex[A]] => Stream[Regex[A]] =
+    CoattrF.un(_) match {
+      case Left(ma) => shrinkMatch[A].apply(ma).map(Coattr.pure[KleeneF, Match[A]](_))
+      case Right(kf) => shrinkKleeneF(kf)
+    }
+
+  def shrinkRegexCoattrFAlgebra[A:Shrink]: AlgebraM[Stream, CoattrF[KleeneF, Match[A], ?], Regex[A]]  = AlgebraM(shrinkRegexCoattrF[A])
+
+  def shrinkRegex[A: Shrink]: Regex[A] => Stream[Regex[A]] =
+    scheme.cataM(shrinkRegexCoattrFAlgebra[A])
+
+  /**
+   * This will "shrink" a regular expression down into similar but simpler regular expressions.  It
+   * isn't `implicit`, because in Scalacheck shrinking isn't integrated into generators which can
+   * lead to confusing results. If you'd like to shrink your regular expression to debug it, you can
+   * create a local `Shrink` instance with something like:
+   *
+   * {{{
+   * implicit val shrinkForCharRegex: Shrink[Regex[Char]] = RegexShrink.shrinkForRegex`
+   * }}}
+   */
+  def shrinkForRegex[A: Shrink]: Shrink[Regex[A]] = Shrink(shrinkRegex[A])
+}

--- a/regex-gen/src/test/scala/RegexShrinkTests.scala
+++ b/regex-gen/src/test/scala/RegexShrinkTests.scala
@@ -1,0 +1,82 @@
+package ceedubs.irrec
+package regex
+
+import cats.Eq
+import cats.tests.CatsSuite
+import org.scalacheck.Shrink, Shrink.shrink
+
+class RegexShrinkTests extends CatsSuite {
+  // this is pretty hacky but I haven't yet written a meaningful equality for regexes.
+  private implicit val eqIntRegex: Eq[Regex[Int]] = Eq.fromUniversalEquals
+  implicit val shrinkIntRegex: Shrink[Regex[Int]] = RegexShrink.shrinkForRegex
+
+  test("shrinking a literal"){
+    val r: Regex[Int] = Regex.lit(2)
+    val expected = List(
+      Regex.lit(1),
+      Regex.lit(-1),
+      Regex.lit(0))
+    shrink(r).toList should ===(expected)
+  }
+
+  test("shrinking a wildcard"){
+    val r: Regex[Int] = Regex.wildcard[Int]
+    val expected = List.empty[Regex[Int]]
+    shrink(r).toList should ===(expected)
+  }
+
+  test("shrinking a range"){
+    val r: Regex[Int] = Regex.range(1, 2)
+    val expected = List(
+      Regex.range(0, 2),
+      Regex.range(1, 1),
+      Regex.range(1, -1),
+      Regex.range(1, 0))
+    shrink(r).toList should ===(expected)
+  }
+
+  test("shrinking a plus"){
+    val r: Regex[Int] = Regex.lit(1) | Regex.lit(1)
+    val expected = List(
+      // shrinking left
+      Regex.lit(0),
+      // shrinking right
+      Regex.lit(0),
+      // shrinking both
+      Regex.lit(0) | Regex.lit(0))
+    shrink(r).toList should ===(expected)
+  }
+
+  test("shrinking a times"){
+    val r: Regex[Int] = Regex.lit(1) * Regex.lit(1)
+    val expected = List(
+      // shrinking left
+      Regex.lit(0),
+      // shrinking right
+      Regex.lit(0),
+      // shrinking both
+      Regex.lit(0) * Regex.lit(0))
+    shrink(r).toList should ===(expected)
+  }
+
+  test("shrinking a * should shrink the inner regex"){
+    val r: Regex[Int] = Regex.lit(2).star
+    val expected = List(
+      Regex.lit(1),
+      Regex.lit(-1),
+      Regex.lit(0))
+    shrink(r).toList should ===(expected)
+  }
+
+  test("zero cannot be shrunk"){
+    val r: Regex[Int] = Regex.impossible
+    val expected = List.empty[Regex[Int]]
+    shrink(r).toList should ===(expected)
+  }
+
+  test("one cannot be shrunk"){
+    val r: Regex[Int] = Regex.empty
+    val expected = List.empty[Regex[Int]]
+    shrink(r).toList should ===(expected)
+  }
+}

--- a/regex/src/main/scala/RegexOps.scala
+++ b/regex/src/main/scala/RegexOps.scala
@@ -29,7 +29,7 @@ final class RegexOps[A](private val r: Regex[A]) extends AnyVal {
 final class CharRegexOps(private val r: Regex[Char]) extends AnyVal {
   def stringMatcher: String => Boolean = Regex.stringMatcher(r)
 
-  def toPattern: Pattern = Pattern.compile(pprint)
+  def toPattern: Pattern = Pattern.compile(pprint, Pattern.DOTALL)
 
   def pprint: String = RegexPrettyPrinter.pprintCharRegex(r)
 }

--- a/regex/src/test/scala/RegexPrettyPrinterTests.scala
+++ b/regex/src/test/scala/RegexPrettyPrinterTests.scala
@@ -2,15 +2,17 @@ package ceedubs.irrec
 package regex
 
 import Regex._
-import org.scalacheck.Arbitrary.arbitrary
-import RegexAndCandidate._
+import CharRegexGen._
 
 class RegexPrettyPrinterTests extends IrrecSuite {
+
   test("char regex pretty printer matches java Pattern"){
-    forAll(genRegexAndMatch(false, arbitrary[Char])){ rm =>
-      val asString = rm.r.pprint
+    forAll(genCharRegexAndMatch){ rm =>
+      val prettyRegex = rm.r.pprint
+      val regexHex = prettyRegex.map(_.toInt.toHexString).toList
       val javaR = rm.r.toPattern
-      assert(javaR.matcher(rm.candidate.mkString).matches, s"${rm.candidate.toList} should match $asString")
+      val candidateHex = rm.candidate.map(_.toInt.toHexString).toList
+      assert(javaR.matcher(rm.candidate.mkString).matches, s"${rm.candidate.mkString} ($candidateHex) should match $prettyRegex ($regexHex)")
     }
   }
 


### PR DESCRIPTION
…tch.

There were a couple of things going on:

1) Certain Unicode characters can effectively combine into a single
character when grouped together.

2) Even once we avoid generating problematic characters in our
`Gen[Char]` instances, we still need to be careful to not creep into
problematic ranges when we are generating `Match.Range[Char]` instances.