### PR TITLE
Remove large minsuccessful from ParserTests

### DIFF
--- a/parser/src/test/scala/ParserTests.scala
+++ b/parser/src/test/scala/ParserTests.scala
@@ -210,7 +210,7 @@ class ParserTests extends IrrecSuite {
   }
 
   test("pretty print parser round trip"){
-    forAll(genCharRegexAndCandidate, minSuccessful(100000)){ case RegexAndCandidate(r, s) =>
+    forAll(genCharRegexAndCandidate){ case RegexAndCandidate(r, s) =>
       val clue = s"regex: (${r.pprint}), candidate: (${s.mkString})"
       parseRegex(r.pprint) match {
         case Failure(label, _, _) => withClue(clue)(fail(s"parsing failure: $label"))


### PR DESCRIPTION
This was used for debugging and wasn't meant to be checked in.