### PR TITLE
Attempt to make AlternativeLaws check faster

### DIFF
--- a/regex-gen/src/main/scala/RegexEq.scala
+++ b/regex-gen/src/main/scala/RegexEq.scala
@@ -15,7 +15,7 @@ import org.scalacheck.rng.Seed
 object RegexEq {
   private val genSeed: Gen[Seed] = Gen.choose(Long.MinValue, Long.MaxValue).map(Seed(_))
 
-  def genRegexEq[In, M](
+  def genRegexEq[In, M](candidateCount: Int)(
     implicit rc: RegexCandidates[In, M]): Gen[Eq ~> λ[a => Eq[Regex[In, M, a]]]] =
     Gen.parameterized { params =>
       genSeed.map { seed =>
@@ -23,11 +23,13 @@ object RegexEq {
           def apply[Out](eqOut: Eq[Out]): Eq[Regex[In, M, Out]] = {
             implicit val impEqOut = eqOut
             Eq.instance { (r1, r2) =>
+              val r1c = r1.compile
+              val r2c = r2.compile
               val candidateGen = Gen.oneOf(rc.genCandidateStream(r1), rc.genCandidateStream(r2))
               val candidates =
-                Gen.listOfN(params.size, candidateGen)(params, seed).getOrElse(List.empty)
+                Gen.listOfN(candidateCount, candidateGen)(params, seed).getOrElse(List.empty)
               candidates.forall { candidate =>
-                r1.compile.parseOnly(candidate) === (r2.compile.parseOnly(candidate))
+                r1c.parseOnly(candidate) === (r2c.parseOnly(candidate))
               }
             }
           }

--- a/tests/src/test/scala/regex/RegexTests.scala
+++ b/tests/src/test/scala/regex/RegexTests.scala
@@ -7,11 +7,11 @@ import gen.RegexGen._
 import cats.Eq
 import cats.implicits._
 import cats.laws.discipline.AlternativeTests
-import org.scalatestplus.scalacheck.Checkers.check
+import org.scalatestplus.scalacheck.Checkers
 
-class RegexTests extends IrrecSuite {
+class RegexTests extends IrrecSuite with Checkers {
   test("Regex Alternative laws") {
-    val gen = RegexEq.genRegexEq[Char, Match[Char]]
+    val gen = RegexEq.genRegexEq[Char, Match[Char]](5)
     forAll(gen, minSuccessful(1)) { rEqv =>
       implicit def mkRegexEq[Out](implicit eqOut: Eq[Out]): Eq[RegexC[Out]] = rEqv(eqOut)
       val ruleSet = AlternativeTests[RegexC].alternative[Int, Int, Int]


### PR DESCRIPTION
It looks like the test configuration wasn't getting picked up by the
version of `check` that I was previously using.