### PR TITLE
Revert to default Travis dist

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 # parts of this were adapted from https://github.com/higherkindness/droste/blob/bad7dae60a0c32e66918613068d6713d209cc6b4/.travis.yml
 language: nix
 sudo: required
-dist: trusty
 
 stages:
   - name: test


### PR DESCRIPTION
I changed this previously to try to fix the build, but I had
misdiagnosed the issue. I don't _think_ that this is necessary.