### PR TITLE
Generalize regexMatchingStreamGen method

### DIFF
--- a/regex-gen/src/main/scala/RegexCandidates.scala
+++ b/regex-gen/src/main/scala/RegexCandidates.scala
@@ -35,7 +35,7 @@ object RegexCandidates {
       def genIn: Gen[Byte] = RegexGen.standardByteConfig.gen
 
       def genMatchingStream[Out](r: Regex[Byte, Match[Byte], Out]): Gen[Stream[Byte]] =
-        regexMatchingStreamGen[Byte](RegexMatchGen.byteMatchingGen)
+        regexMMatchingStreamGen[Byte](RegexMatchGen.byteMatchingGen)
           .apply(r)
     }
 
@@ -44,7 +44,7 @@ object RegexCandidates {
       def genIn: Gen[Int] = RegexGen.standardIntConfig.gen
 
       def genMatchingStream[Out](r: Regex[Int, Match[Int], Out]): Gen[Stream[Int]] =
-        regexMatchingStreamGen[Int](RegexMatchGen.intMatchingGen)
+        regexMMatchingStreamGen[Int](RegexMatchGen.intMatchingGen)
           .apply(r)
     }
 
@@ -53,7 +53,7 @@ object RegexCandidates {
       def genIn: Gen[Long] = RegexGen.standardLongConfig.gen
 
       def genMatchingStream[Out](r: Regex[Long, Match[Long], Out]): Gen[Stream[Long]] =
-        regexMatchingStreamGen[Long](RegexMatchGen.longMatchingGen)
+        regexMMatchingStreamGen[Long](RegexMatchGen.longMatchingGen)
           .apply(r)
     }
 }

--- a/regex-gen/src/main/scala/RegexMatchGen.scala
+++ b/regex-gen/src/main/scala/RegexMatchGen.scala
@@ -30,36 +30,41 @@ object RegexMatchGen {
   val longMatchingGen: Match[Long] => Gen[Long] =
     dietMatchToGen(Diet.fromRange(Range(Long.MinValue, Long.MaxValue)), dietMatchingGen(_))
 
-  def regexMatchingStreamGen[In](
-    matchGen: Match[In] => Gen[In]): RegexM[In, ?] ~> λ[a => Gen[Stream[In]]] =
-    new (RegexM[In, ?] ~> λ[a => Gen[Stream[In]]]) { outer =>
-      def apply[Out](fa: RegexM[In, Out]): Gen[Stream[In]] =
-        Regex.fold[In, Match[In], Out, Gen[Stream[In]]](
+  def regexMatchingStreamGen[In, M](
+    matchGen: M => Gen[In]): Regex[In, M, ?] ~> λ[a => Gen[Stream[In]]] =
+    new (Regex[In, M, ?] ~> λ[a => Gen[Stream[In]]]) { outer =>
+      def apply[Out](fa: Regex[In, M, Out]): Gen[Stream[In]] =
+        Regex.fold[In, M, Out, Gen[Stream[In]]](
           eps = _ => Gen.const(Stream.empty),
           fail = () => Gen.fail,
           elem = (m, _) => matchGen(m).map(Stream(_)),
-          andThen = λ[λ[i => (RegexM[In, i => Out], RegexM[In, i])] ~> λ[a => Gen[Stream[In]]]](t =>
-            outer.apply(t._1).map2(outer.apply(t._2))(_ ++ _)),
-          star =
-            λ[λ[i => (RegexM[In, i], Greediness, Out, (Out, i) => Out)] ~> λ[a => Gen[Stream[In]]]](
-              t => Gen.containerOf[Stream, Stream[In]](outer.apply(t._1)).map(_.flatten)),
-          repeat =
-            λ[λ[i => (RegexM[In, i], Quantifier, Out, (Out, i) => Out)] ~> λ[a => Gen[Stream[In]]]](
-              t =>
-                for {
-                  count <- QuantifierGen.genCount(t._2)
-                  nestedStream <- Gen.containerOfN[Stream, Stream[In]](count, outer.apply(t._1))
-                } yield nestedStream.flatten),
-          mapped =
-            λ[λ[a => (RegexM[In, a], a => Out)] ~> λ[a => Gen[Stream[In]]]](t => outer.apply(t._1)),
+          andThen =
+            λ[λ[i => (Regex[In, M, i => Out], Regex[In, M, i])] ~> λ[a => Gen[Stream[In]]]](t =>
+              outer.apply(t._1).map2(outer.apply(t._2))(_ ++ _)),
+          star = λ[
+            λ[i => (Regex[In, M, i], Greediness, Out, (Out, i) => Out)] ~> λ[a => Gen[Stream[In]]]](
+            t => Gen.containerOf[Stream, Stream[In]](outer.apply(t._1)).map(_.flatten)),
+          repeat = λ[
+            λ[i => (Regex[In, M, i], Quantifier, Out, (Out, i) => Out)] ~> λ[a => Gen[Stream[In]]]](
+            t =>
+              for {
+                count <- QuantifierGen.genCount(t._2)
+                nestedStream <- Gen.containerOfN[Stream, Stream[In]](count, outer.apply(t._1))
+              } yield nestedStream.flatten),
+          mapped = λ[λ[a => (Regex[In, M, a], a => Out)] ~> λ[a => Gen[Stream[In]]]](t =>
+            outer.apply(t._1)),
           or = alternatives => Gen.oneOf(alternatives.toList).flatMap(apply),
-          void = _ => λ[RegexM[In, ?] ~> λ[a => Gen[Stream[In]]]](outer.apply(_))
+          void = _ => λ[Regex[In, M, ?] ~> λ[a => Gen[Stream[In]]]](outer.apply(_))
         )(fa)
     }
 
+  def regexMMatchingStreamGen[In](
+    matchGen: Match[In] => Gen[In]): RegexM[In, ?] ~> λ[a => Gen[Stream[In]]] =
+    regexMatchingStreamGen(matchGen)
+
   def dietRegexMatchingStreamGen[In: Choose: Discrete: Order, Out](
     available: Diet[In]): RegexM[In, Out] => Gen[Stream[In]] =
-    regexMatchingStreamGen[In](dietMatchToGen(available, dietMatchingGen(_))).apply
+    regexMMatchingStreamGen[In](dietMatchToGen(available, dietMatchingGen(_))).apply
 
   def genRegexMatch[In, M, Out](r: Regex[In, M, Out])(implicit
     rc: RegexCandidates[In, M]): Gen[Stream[In]] =

--- a/tests/src/test/scala/regex-gen/RegexMatchGenTests.scala
+++ b/tests/src/test/scala/regex-gen/RegexMatchGenTests.scala
@@ -12,7 +12,7 @@ import org.scalacheck.Arbitrary.arbitrary
 class RegexMatchGenTests extends IrrecSuite {
   test("regexMatchingStreamGen generates a failing stream for fail") {
     val r: RegexC[Long] = combinator.fail
-    val gen = regexMatchingStreamGen[Char](_ => Gen.const('a')).apply(r)
+    val gen = regexMMatchingStreamGen[Char](_ => Gen.const('a')).apply(r)
     gen.sample should ===(None)
   }
 


### PR DESCRIPTION
There was no reason for it to be fixed to `Match`.